### PR TITLE
Set Content-Type header before the image is written to the response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/image-faker",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Fake image generator using the PHP GD library. Accessible through a Laravel route.",
     "license": "MIT",
     "authors": [

--- a/src/ImageFakerController.php
+++ b/src/ImageFakerController.php
@@ -36,9 +36,10 @@ class ImageFakerController extends Controller
 
         $image = $this->image->create($dimensions['width'], $dimensions['height'], $request->text);
 
+        header("Content-Type: image/png");
         imagepng($image);
         imagedestroy($image);
 
-        return response(200)->header('Content-Type', 'image/png');
+        return response(200);
     }
 }


### PR DESCRIPTION
## Issue

Content-Type was not being set correctly, came back as `html`.

## Solution

Set the header before the image is written to the response.

| Before | After |
|--------|--------|
| ![Screenshot 2023-03-07 at 11 00 17 AM](https://user-images.githubusercontent.com/37359/223485221-3f4a66e9-8dec-4f70-a8bc-363dac868860.png) | ![Screenshot 2023-03-07 at 11 00 28 AM](https://user-images.githubusercontent.com/37359/223485239-8e65ba6c-fe82-4d4f-8433-50ac57d92407.png) |