### PR TITLE
Hotfix 1.0.3 | Fix issue with headers being sent before the response was sent, consolidate headers with the response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/image-faker",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Fake image generator using the PHP GD library. Accessible through a Laravel route.",
     "license": "MIT",
     "authors": [

--- a/src/ImageFakerController.php
+++ b/src/ImageFakerController.php
@@ -36,10 +36,14 @@ class ImageFakerController extends Controller
 
         $image = $this->image->create($dimensions['width'], $dimensions['height'], $request->text);
 
-        header("Content-Type: image/png");
+        ob_start();
         imagepng($image);
+        $image_data = ob_get_contents();
         imagedestroy($image);
-
-        return response(200);
+        ob_end_clean();
+        
+        return response($image_data, 200, [
+            'Content-Type' => 'image/png'
+        ]);
     }
 }


### PR DESCRIPTION
From https://github.com/waynestate/image-faker/pull/4 the Content Type was being sent early and then having the response sent as well. This combines the image, header and response all together.